### PR TITLE
set allowCrossProtocolRedirects true this fixes #14

### DIFF
--- a/app/src/main/java/de/nicidienase/chaosflix/activities/PlayerActivity.java
+++ b/app/src/main/java/de/nicidienase/chaosflix/activities/PlayerActivity.java
@@ -35,6 +35,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.Util;
@@ -310,6 +311,9 @@ public class PlayerActivity extends AbstractServiceConnectedActivity
 	}
 
 	private HttpDataSource.Factory buildHttpDataSourceFactory(DefaultBandwidthMeter bandwidthMeter) {
-		return new DefaultHttpDataSourceFactory(mUserAgent, bandwidthMeter);
+		return new DefaultHttpDataSourceFactory(mUserAgent, bandwidthMeter,
+				DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+				DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+				true /* allowCrossProtocolRedirects */);
 	}
 }


### PR DESCRIPTION
This fixes issue #14 for me. But as I've seen you have done a refactoring. Unfortunately I can't play anything with the latest version. I'll try to figure things out and make it working again. So I took the latest release for fixing my problem. 

Because some weird reason exoplanet did not follow the 302 redirect on my device. But with allowCrossProtocolRedirects set to true, everything works fine for me.

With latest commits I can't choose anything from the main menu. Nothing happens at all. I'll try to figure that out if I found some time.